### PR TITLE
feat: Phase 3 complete — intermediate models and marts

### DIFF
--- a/housing_pipeline/models/intermediate/int_crime_index.sql
+++ b/housing_pipeline/models/intermediate/int_crime_index.sql
@@ -1,0 +1,63 @@
+-- models/intermediate/int_crime_index.sql
+
+with crimes as (
+
+    select
+        zip_code,
+        year(incident_occurred)     as incident_year,
+        incident_type
+
+    from {{ ref('stg_crime_incidents') }}
+
+),
+
+annual_counts as (
+
+    select
+        zip_code,
+        incident_year,
+        count(*)                    as incident_count
+
+    from crimes
+
+    group by
+        zip_code,
+        incident_year
+
+),
+
+demographics as (
+
+    select
+        zip_code,
+        total_population
+
+    from {{ ref('int_zip_demographics') }}
+
+),
+
+joined as (
+
+    select
+        a.zip_code,
+        a.incident_year,
+        a.incident_count,
+        d.total_population,
+        round(
+            a.incident_count / nullif(d.total_population, 0) * 1000,
+            2
+        )                           as incidents_per_1k
+
+    from annual_counts a
+    inner join demographics d on a.zip_code = d.zip_code
+
+)
+
+select
+    zip_code,
+    incident_year,
+    incident_count,
+    total_population,
+    incidents_per_1k
+
+from joined

--- a/housing_pipeline/models/intermediate/int_market_activity.sql
+++ b/housing_pipeline/models/intermediate/int_market_activity.sql
@@ -1,0 +1,54 @@
+-- models/intermediate/int_market_activity.sql
+
+with redfin as (
+
+    select
+        zip_code,
+        period_end,
+        median_dom,
+        inventory,
+        avg_sale_to_list,
+        months_of_supply,
+        median_sale_price,
+        homes_sold,
+        new_listings
+
+    from {{ ref('stg_redfin') }}
+
+),
+
+monthly as (
+
+    select
+        zip_code,
+        date_trunc('month', period_end)     as period_month,
+        median(median_dom)                  as median_dom,
+        median(inventory)                   as median_inventory,
+        median(avg_sale_to_list)            as median_avg_sale_to_list,
+        median(months_of_supply)            as median_months_of_supply,
+        median(median_sale_price)           as median_sale_price,
+        median(homes_sold)                  as median_homes_sold,
+        median(new_listings)                as median_new_listings,
+        count(*)                            as week_count
+
+    from redfin
+
+    group by
+        zip_code,
+        date_trunc('month', period_end)
+
+)
+
+select
+    zip_code,
+    period_month,
+    median_dom,
+    median_inventory,
+    median_avg_sale_to_list,
+    median_months_of_supply,
+    median_sale_price,
+    median_homes_sold,
+    median_new_listings,
+    week_count
+
+from monthly

--- a/housing_pipeline/models/intermediate/int_zip_demographics.sql
+++ b/housing_pipeline/models/intermediate/int_zip_demographics.sql
@@ -1,0 +1,62 @@
+-- models/intermediate/int_zip_demographics.sql
+
+with census as (
+
+    select
+        zip_code,
+        median_household_income,
+        poverty_count,
+        total_population,
+        vintage_year
+
+    from {{ ref('stg_census_zip') }}
+
+    where vintage_year = 2023
+
+),
+
+regions as (
+
+    select
+        zip_code,
+        nashville_region,
+        county_name,
+        county_fips
+
+    from {{ ref('nashville_zip_regions') }}
+
+),
+
+joined as (
+
+    select
+        c.zip_code,
+        r.nashville_region,
+        r.county_name,
+        r.county_fips,
+        c.median_household_income,
+        c.poverty_count,
+        c.total_population,
+        round(
+            c.poverty_count / nullif(c.total_population, 0),
+            4
+        )                           as poverty_rate,
+        c.vintage_year
+
+    from census c
+    inner join regions r on c.zip_code = r.zip_code
+
+)
+
+select
+    zip_code,
+    nashville_region,
+    county_name,
+    county_fips,
+    median_household_income,
+    poverty_count,
+    total_population,
+    poverty_rate,
+    vintage_year
+
+from joined

--- a/housing_pipeline/models/marts/dim_geography.sql
+++ b/housing_pipeline/models/marts/dim_geography.sql
@@ -1,0 +1,31 @@
+-- models/marts/dim_geography.sql
+
+with demographics as (
+
+    select
+        zip_code,
+        nashville_region,
+        county_name,
+        county_fips,
+        median_household_income,
+        poverty_count,
+        total_population,
+        poverty_rate,
+        vintage_year
+
+    from {{ ref('int_zip_demographics') }}
+
+)
+
+select
+    zip_code,
+    nashville_region,
+    county_name,
+    county_fips,
+    median_household_income,
+    poverty_count,
+    total_population,
+    poverty_rate,
+    vintage_year
+
+from demographics

--- a/housing_pipeline/models/marts/fct_monthly_zip.sql
+++ b/housing_pipeline/models/marts/fct_monthly_zip.sql
@@ -1,0 +1,77 @@
+-- models/marts/fct_monthly_zip.sql
+
+with market as (
+
+    select
+        zip_code,
+        period_month,
+        median_dom,
+        median_inventory,
+        median_avg_sale_to_list,
+        median_months_of_supply,
+        median_sale_price,
+        median_homes_sold,
+        median_new_listings,
+        week_count
+
+    from {{ ref('int_market_activity') }}
+
+),
+
+zillow_pivot as (
+
+    select
+        zip_code,
+        date_trunc('month', period_month)               as period_month,
+        max(case when metric_type = 'ZHVI' then value end) as zhvi,
+        max(case when metric_type = 'ZORI' then value end) as zori,
+        max(case when metric_type = 'ZHVF' then value end) as zhvf
+
+    from {{ ref('stg_zillow') }}
+
+    group by
+        zip_code,
+        date_trunc('month', period_month)
+
+),
+
+joined as (
+
+    select
+        m.zip_code,
+        m.period_month,
+        m.median_dom,
+        m.median_inventory,
+        m.median_avg_sale_to_list,
+        m.median_months_of_supply,
+        m.median_sale_price,
+        m.median_homes_sold,
+        m.median_new_listings,
+        m.week_count,
+        z.zhvi,
+        z.zori,
+        z.zhvf
+
+    from market m
+    left join zillow_pivot z
+        on  m.zip_code     = z.zip_code
+        and m.period_month = z.period_month
+
+)
+
+select
+    zip_code,
+    period_month,
+    median_dom,
+    median_inventory,
+    median_avg_sale_to_list,
+    median_months_of_supply,
+    median_sale_price,
+    median_homes_sold,
+    median_new_listings,
+    week_count,
+    zhvi,
+    zori,
+    zhvf
+
+from joined

--- a/housing_pipeline/models/marts/fct_opportunity_score.sql
+++ b/housing_pipeline/models/marts/fct_opportunity_score.sql
@@ -1,0 +1,193 @@
+-- models/marts/fct_opportunity_score.sql
+
+with latest_market as (
+
+    select
+        zip_code,
+        period_month,
+        median_sale_price,
+        median_dom,
+        median_homes_sold
+
+    from {{ ref('fct_monthly_zip') }}
+
+    qualify row_number() over (
+        partition by zip_code
+        order by period_month desc
+    ) = 1
+
+),
+
+latest_crime as (
+
+    select
+        zip_code,
+        incident_year,
+        incidents_per_1k
+
+    from {{ ref('int_crime_index') }}
+
+    qualify row_number() over (
+        partition by zip_code
+        order by incident_year desc
+    ) = 1
+
+),
+
+geography as (
+
+    select
+        zip_code,
+        nashville_region,
+        county_name,
+        county_fips,
+        median_household_income,
+        poverty_rate
+
+    from {{ ref('dim_geography') }}
+
+),
+
+combined as (
+
+    select
+        g.zip_code,
+        g.nashville_region,
+        g.county_name,
+        g.county_fips,
+        lm.period_month             as market_as_of,
+        lc.incident_year            as crime_as_of,
+        lm.median_sale_price,
+        lm.median_dom,
+        lm.median_homes_sold,
+        g.median_household_income,
+        g.poverty_rate,
+        lc.incidents_per_1k
+
+    from geography g
+    left join latest_market lm  on g.zip_code = lm.zip_code
+    left join latest_crime lc   on g.zip_code = lc.zip_code
+
+),
+
+normalized as (
+
+    select
+        zip_code,
+        nashville_region,
+        county_name,
+        county_fips,
+        market_as_of,
+        crime_as_of,
+        median_sale_price,
+        median_dom,
+        median_homes_sold,
+        median_household_income,
+        poverty_rate,
+        incidents_per_1k,
+
+        -- affordability: lower price = higher score
+        round(
+            (1 - (median_sale_price - min(median_sale_price) over ())
+                / nullif(max(median_sale_price) over () - min(median_sale_price) over (), 0)
+            ) * 100, 2
+        )                           as affordability_score,
+
+        -- market speed: lower dom = higher score
+        round(
+            (1 - (median_dom - min(median_dom) over ())
+                / nullif(max(median_dom) over () - min(median_dom) over (), 0)
+            ) * 100, 2
+        )                           as market_speed_score,
+
+        -- activity: higher homes sold = higher score
+        round(
+            (median_homes_sold - min(median_homes_sold) over ())
+            / nullif(max(median_homes_sold) over () - min(median_homes_sold) over (), 0)
+            * 100, 2
+        )                           as activity_score,
+
+        -- income: higher income = higher score
+        round(
+            (median_household_income - min(median_household_income) over ())
+            / nullif(max(median_household_income) over () - min(median_household_income) over (), 0)
+            * 100, 2
+        )                           as income_score,
+
+        -- poverty: lower rate = higher score
+        round(
+            (1 - (poverty_rate - min(poverty_rate) over ())
+                / nullif(max(poverty_rate) over () - min(poverty_rate) over (), 0)
+            ) * 100, 2
+        )                           as poverty_score,
+
+        -- safety: lower crime = higher score (coalesce nulls to 50 — neutral for suburban zips)
+        round(
+            (1 - (coalesce(incidents_per_1k, avg(incidents_per_1k) over ())
+                    - min(coalesce(incidents_per_1k, 0)) over ())
+                / nullif(max(incidents_per_1k) over () - min(incidents_per_1k) over (), 0)
+            ) * 100, 2
+        )                           as safety_score
+
+    from combined
+
+),
+
+scored as (
+
+    select
+        zip_code,
+        nashville_region,
+        county_name,
+        county_fips,
+        market_as_of,
+        crime_as_of,
+        median_sale_price,
+        median_dom,
+        median_homes_sold,
+        median_household_income,
+        poverty_rate,
+        incidents_per_1k,
+        affordability_score,
+        market_speed_score,
+        activity_score,
+        income_score,
+        poverty_score,
+        safety_score,
+        round(
+            (
+                coalesce(affordability_score, 50)
+                + coalesce(market_speed_score, 50)
+                + coalesce(activity_score, 50)
+                + coalesce(income_score, 50)
+                + coalesce(poverty_score, 50)
+                + coalesce(safety_score, 50)
+            ) / 6, 2
+        )                           as opportunity_score
+
+    from normalized
+
+)
+
+select
+    zip_code,
+    nashville_region,
+    county_name,
+    county_fips,
+    market_as_of,
+    crime_as_of,
+    median_sale_price,
+    median_dom,
+    median_homes_sold,
+    median_household_income,
+    poverty_rate,
+    incidents_per_1k,
+    affordability_score,
+    market_speed_score,
+    activity_score,
+    income_score,
+    poverty_score,
+    safety_score,
+    opportunity_score
+
+from scored


### PR DESCRIPTION
- int_zip_demographics: 76 zips, 2023 census vintage, poverty_rate derived
- int_market_activity: 10,650 rows, Redfin weekly → monthly aggregation
- int_crime_index: 308 rows, 53 Davidson County zips, 2019–2026
- fct_monthly_zip: 10,650 rows, Redfin spine + Zillow pivot, date_trunc alignment fix
- dim_geography: 76 rows, one per MSA zip, dominant_lu_code dropped
- fct_opportunity_score: 76 rows, 6-signal min-max normalized composite score (40.66–81.87)