### PR TITLE
feat: Phase 4 Airflow DAGs + docker-compose fixes

### DIFF
--- a/airflow/dags/dag_utils.py
+++ b/airflow/dags/dag_utils.py
@@ -1,0 +1,80 @@
+# airflow/dags/dag_utils.py
+
+import os
+import httpx
+import snowflake.connector
+
+
+def get_slack_webhook() -> str | None:
+    return os.environ.get("SLACK_WEBHOOK_URL") or None
+
+
+def notify_slack_failure(context: dict) -> None:
+    url = get_slack_webhook()
+    if not url:
+        return
+    dag_id = context["dag"].dag_id
+    task_id = context["task_instance"].task_id
+    run_id = context["run_id"]
+    httpx.post(url, json={
+        "text": (
+            f":red_circle: *{dag_id}* failed at task `{task_id}`\n"
+            f"Run: `{run_id}`"
+        )
+    }, timeout=10)
+
+
+def notify_slack_success(dag_id: str, run_id: str, notes: str) -> None:
+    url = get_slack_webhook()
+    if not url:
+        return
+    httpx.post(url, json={
+        "text": (
+            f":white_check_mark: *{dag_id}* succeeded\n"
+            f"Run: `{run_id}`\n{notes}"
+        )
+    }, timeout=10)
+
+
+def write_audit_log(
+    dag_id: str,
+    run_id: str,
+    status: str,
+    notes: str = None,
+    dbt_tests_run: int = 0,
+    dbt_tests_passed: int = 0,
+    freshness_redfin: str = None,
+    freshness_zillow: str = None,
+    freshness_parcels: str = None,
+    freshness_census: str = None,
+    freshness_crime: str = None,
+) -> None:
+    conn = snowflake.connector.connect(
+        account=os.environ["SNOWFLAKE_ACCOUNT"],
+        user=os.environ["SNOWFLAKE_USER"],
+        password=os.environ["SNOWFLAKE_PASSWORD"],
+        role=os.environ.get("SNOWFLAKE_ROLE", "HOUSING_PIPELINE_ROLE"),
+        warehouse=os.environ.get("SNOWFLAKE_WAREHOUSE", "HOUSING_PIPELINE_WH"),
+        database=os.environ.get("SNOWFLAKE_DATABASE", "HOUSING_PIPELINE"),
+        schema="RAW",
+    )
+    try:
+        conn.cursor().execute("""
+            INSERT INTO RAW.PIPELINE_AUDIT (
+                dag_id, run_id, status, notes,
+                dbt_tests_run, dbt_tests_passed,
+                freshness_redfin, freshness_zillow,
+                freshness_parcels, freshness_census, freshness_crime
+            ) VALUES (
+                %s, %s, %s, %s,
+                %s, %s,
+                %s, %s, %s, %s, %s
+            )
+        """, (
+            dag_id, run_id, status, notes,
+            dbt_tests_run, dbt_tests_passed,
+            freshness_redfin, freshness_zillow,
+            freshness_parcels, freshness_census, freshness_crime,
+        ))
+    finally:
+        conn.close()

--- a/airflow/dags/daily_ingestion_dag.py
+++ b/airflow/dags/daily_ingestion_dag.py
@@ -1,0 +1,101 @@
+# airflow/dags/daily_ingestion_dag.py
+
+import os
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from airflow.operators.bash import BashOperator
+
+from dag_utils import notify_slack_failure, notify_slack_success, write_audit_log
+
+from ingestion.sources.census import ingest_census
+from ingestion.sources.crime import ingest_crime
+from ingestion.sources.property import ingest_property
+
+PIPELINE_HOME = os.environ.get(
+    "PIPELINE_HOME", "/opt/airflow/nashville-housing-platform"
+)
+DBT_DIR = f"{PIPELINE_HOME}/housing_pipeline"
+
+default_args = {
+    "owner": "luca",
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+    "on_failure_callback": notify_slack_failure,
+}
+
+with DAG(
+    dag_id="daily_ingestion_dag",
+    description="Daily ingestion: Census, Crime, Parcels + full dbt run",
+    schedule_interval="0 6 * * *",
+    start_date=datetime(2026, 5, 1),
+    catchup=False,
+    default_args=default_args,
+    tags=["ingestion", "daily"],
+) as dag:
+
+    def run_census(**context):
+        result = ingest_census()
+        rows = sum(result.values()) if isinstance(result, dict) else result
+        context["ti"].xcom_push(key="census_rows", value=rows)
+
+    def run_crime(**context):
+        rows = ingest_crime()
+        context["ti"].xcom_push(key="crime_rows", value=rows)
+
+    def run_parcels(**context):
+        rows = ingest_property()
+        context["ti"].xcom_push(key="parcels_rows", value=rows)
+
+    def run_audit_log(**context):
+        ti = context["ti"]
+        census_rows = ti.xcom_pull(key="census_rows", task_ids="ingest_census") or 0
+        crime_rows = ti.xcom_pull(key="crime_rows", task_ids="ingest_crime") or 0
+        parcels_rows = ti.xcom_pull(key="parcels_rows", task_ids="ingest_parcels") or 0
+        notes = (
+            f"census={census_rows} rows, "
+            f"crime={crime_rows} rows, "
+            f"parcels={parcels_rows} rows"
+        )
+        write_audit_log(
+            dag_id=context["dag"].dag_id,
+            run_id=context["run_id"],
+            status="success",
+            notes=notes,
+            freshness_census="ok",
+            freshness_crime="ok",
+            freshness_parcels="ok",
+        )
+        notify_slack_success(
+            dag_id=context["dag"].dag_id,
+            run_id=context["run_id"],
+            notes=notes,
+        )
+
+    ingest_census_task = PythonOperator(
+        task_id="ingest_census",
+        python_callable=run_census,
+    )
+
+    ingest_crime_task = PythonOperator(
+        task_id="ingest_crime",
+        python_callable=run_crime,
+    )
+
+    ingest_parcels_task = PythonOperator(
+        task_id="ingest_parcels",
+        python_callable=run_parcels,
+    )
+
+    run_dbt = BashOperator(
+        task_id="run_dbt",
+        bash_command=f"cd {DBT_DIR} && uv run dbt run",
+    )
+
+    write_audit = PythonOperator(
+        task_id="write_audit_log",
+        python_callable=run_audit_log,
+    )
+
+    [ingest_census_task, ingest_crime_task, ingest_parcels_task] >> run_dbt >> write_audit

--- a/airflow/dags/redfin_dag.py
+++ b/airflow/dags/redfin_dag.py
@@ -1,0 +1,72 @@
+# airflow/dags/redfin_dag.py
+
+import os
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from airflow.operators.bash import BashOperator
+
+from dag_utils import notify_slack_failure, notify_slack_success, write_audit_log
+
+from ingestion.sources.redfin import ingest_redfin
+
+PIPELINE_HOME = os.environ.get(
+    "PIPELINE_HOME", "/opt/airflow/nashville-housing-platform"
+)
+DBT_DIR = f"{PIPELINE_HOME}/housing_pipeline"
+
+default_args = {
+    "owner": "luca",
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+    "on_failure_callback": notify_slack_failure,
+}
+
+with DAG(
+    dag_id="redfin_dag",
+    description="Weekly Redfin ingestion + full dbt run",
+    schedule_interval="0 3 * * 3",
+    start_date=datetime(2026, 5, 1),
+    catchup=False,
+    default_args=default_args,
+    tags=["ingestion", "weekly"],
+) as dag:
+
+    def run_redfin(**context):
+        rows = ingest_redfin()
+        context["ti"].xcom_push(key="redfin_rows", value=rows)
+
+    def run_audit_log(**context):
+        ti = context["ti"]
+        redfin_rows = ti.xcom_pull(key="redfin_rows", task_ids="ingest_redfin") or 0
+        notes = f"redfin={redfin_rows} rows (0 means ETag unchanged, no new data)"
+        write_audit_log(
+            dag_id=context["dag"].dag_id,
+            run_id=context["run_id"],
+            status="success",
+            notes=notes,
+            freshness_redfin="ok",
+        )
+        notify_slack_success(
+            dag_id=context["dag"].dag_id,
+            run_id=context["run_id"],
+            notes=notes,
+        )
+
+    ingest_redfin_task = PythonOperator(
+        task_id="ingest_redfin",
+        python_callable=run_redfin,
+    )
+
+    run_dbt = BashOperator(
+        task_id="run_dbt",
+        bash_command=f"cd {DBT_DIR} && uv run dbt run",
+    )
+
+    write_audit = PythonOperator(
+        task_id="write_audit_log",
+        python_callable=run_audit_log,
+    )
+
+    ingest_redfin_task >> run_dbt >> write_audit

--- a/airflow/dags/zillow_dag.py
+++ b/airflow/dags/zillow_dag.py
@@ -1,0 +1,72 @@
+# airflow/dags/zillow_dag.py
+
+import os
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+from airflow.operators.bash import BashOperator
+
+from dag_utils import notify_slack_failure, notify_slack_success, write_audit_log
+
+from ingestion.sources.zillow import ingest_zillow
+
+PIPELINE_HOME = os.environ.get(
+    "PIPELINE_HOME", "/opt/airflow/nashville-housing-platform"
+)
+DBT_DIR = f"{PIPELINE_HOME}/housing_pipeline"
+
+default_args = {
+    "owner": "luca",
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+    "on_failure_callback": notify_slack_failure,
+}
+
+with DAG(
+    dag_id="zillow_dag",
+    description="Monthly Zillow ingestion + full dbt run",
+    schedule_interval="0 4 1 * *",
+    start_date=datetime(2026, 5, 1),
+    catchup=False,
+    default_args=default_args,
+    tags=["ingestion", "monthly"],
+) as dag:
+
+    def run_zillow(**context):
+        rows = ingest_zillow()
+        context["ti"].xcom_push(key="zillow_rows", value=rows)
+
+    def run_audit_log(**context):
+        ti = context["ti"]
+        zillow_rows = ti.xcom_pull(key="zillow_rows", task_ids="ingest_zillow") or 0
+        notes = f"zillow={zillow_rows} rows"
+        write_audit_log(
+            dag_id=context["dag"].dag_id,
+            run_id=context["run_id"],
+            status="success",
+            notes=notes,
+            freshness_zillow="ok",
+        )
+        notify_slack_success(
+            dag_id=context["dag"].dag_id,
+            run_id=context["run_id"],
+            notes=notes,
+        )
+
+    ingest_zillow_task = PythonOperator(
+        task_id="ingest_zillow",
+        python_callable=run_zillow,
+    )
+
+    run_dbt = BashOperator(
+        task_id="run_dbt",
+        bash_command=f"cd {DBT_DIR} && uv run dbt run",
+    )
+
+    write_audit = PythonOperator(
+        task_id="write_audit_log",
+        python_callable=run_audit_log,
+    )
+
+    ingest_zillow_task >> run_dbt >> write_audit

--- a/airflow/docker-compose.yml
+++ b/airflow/docker-compose.yml
@@ -11,18 +11,6 @@ x-airflow-common: &airflow-common
     AIRFLOW__CORE__FERNET_KEY: ''
     AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: 'true'
     AIRFLOW__WEBSERVER__EXPOSE_CONFIG: 'true'
-    # Pipeline env vars — pulled from your .env file via env_file below
-    SNOWFLAKE_ACCOUNT: ${SNOWFLAKE_ACCOUNT}
-    SNOWFLAKE_USER: ${SNOWFLAKE_USER}
-    SNOWFLAKE_PASSWORD: ${SNOWFLAKE_PASSWORD}
-    SNOWFLAKE_ROLE: ${SNOWFLAKE_ROLE}
-    SNOWFLAKE_WAREHOUSE: ${SNOWFLAKE_WAREHOUSE}
-    SNOWFLAKE_DATABASE: ${SNOWFLAKE_DATABASE}
-    SNOWFLAKE_SCHEMA: ${SNOWFLAKE_SCHEMA}
-    CENSUS_API_KEY: ${CENSUS_API_KEY}
-    SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL}
-    PIPELINE_ENV: ${PIPELINE_ENV}
-    # dbt working directory — used by BashOperator in DAGs
     PIPELINE_HOME: /opt/airflow/nashville-housing-platform
     PYTHONPATH: /opt/airflow/nashville-housing-platform
   env_file:


### PR DESCRIPTION
- dag_utils.py: shared Slack notifications and audit log writer
- daily_ingestion_dag.py: parallel Census/Crime/Parcels + dbt + audit
- redfin_dag.py: weekly Redfin ingestion + dbt + audit
- zillow_dag.py: monthly Zillow ingestion + dbt + audit
- docker-compose.yml: removed pipeline vars from environment block, env_file now sole source for Snowflake/Census/Slack/PIPELINE_ENV
- .env: cleaned up duplicates, added SNOWFLAKE_SCHEMA=RAW