### PR TITLE
fix: parcels OwnDate conversion and audit log schema fixes

### DIFF
--- a/airflow/dags/dag_utils.py
+++ b/airflow/dags/dag_utils.py
@@ -45,9 +45,9 @@ def write_audit_log(
     dbt_tests_passed: int = 0,
     freshness_redfin: str = None,
     freshness_zillow: str = None,
-    freshness_parcels: str = None,
-    freshness_census: str = None,
+    freshness_property: str = None,
     freshness_crime: str = None,
+    freshness_census: str = None,
 ) -> None:
     conn = snowflake.connector.connect(
         account=os.environ["SNOWFLAKE_ACCOUNT"],
@@ -64,7 +64,7 @@ def write_audit_log(
                 dag_id, run_id, status, notes,
                 dbt_tests_run, dbt_tests_passed,
                 freshness_redfin, freshness_zillow,
-                freshness_parcels, freshness_census, freshness_crime
+                freshness_property, freshness_crime, freshness_census
             ) VALUES (
                 %s, %s, %s, %s,
                 %s, %s,
@@ -74,7 +74,7 @@ def write_audit_log(
             dag_id, run_id, status, notes,
             dbt_tests_run, dbt_tests_passed,
             freshness_redfin, freshness_zillow,
-            freshness_parcels, freshness_census, freshness_crime,
+            freshness_property, freshness_crime, freshness_census,
         ))
     finally:
         conn.close()

--- a/airflow/dags/daily_ingestion_dag.py
+++ b/airflow/dags/daily_ingestion_dag.py
@@ -65,7 +65,7 @@ with DAG(
             notes=notes,
             freshness_census="ok",
             freshness_crime="ok",
-            freshness_parcels="ok",
+            freshness_property="ok",
         )
         notify_slack_success(
             dag_id=context["dag"].dag_id,

--- a/ingestion/sources/property.py
+++ b/ingestion/sources/property.py
@@ -259,11 +259,17 @@ def transform_parcels(df: pl.DataFrame) -> pl.DataFrame:
     # Step 2: cast to Int64 (required by Polars for from_epoch)
     # Step 3: cast to Date
     df = df.with_columns(
-        (pl.col("OwnDate") / 1000)
-        .cast(pl.Int64)
-        .cast(pl.Date)
-        .alias("OwnDate")
+        pl.from_epoch(
+            (pl.col("OwnDate") / 1000).cast(pl.Int64),
+            time_unit="s"
+        ).alias("OwnDate")
     )
+    # Drop rows where OwnDate is out of Polars' valid date range
+    before_range = df.shape[0]
+    df = df.drop_nulls(subset=["OwnDate"])
+    dropped_range = before_range - df.shape[0]
+    if dropped_range > 0:
+        logger.warning(f"[parcels] Dropped {dropped_range} rows with out-of-range OwnDate")
 
     # Cast numeric fields — ArcGIS may return these as int or null
     df = df.with_columns([
@@ -375,9 +381,9 @@ def ingest_property() -> int:
     new_watermark = df["own_date"].max().strftime("%Y-%m-%d")
 
     logger.info(
-        f"[parcels] Writing {df.shape[0]:,} rows "
-        f"(own_date range: {df['own_date'].min()} → {new_watermark})"
-    )
+            f"[parcels] Writing {df.shape[0]:,} rows "
+            f"(own_date range: {df['own_date'].min()} → {new_watermark})"
+        )
 
     _delete_date_range(fetch_from_date)
 


### PR DESCRIPTION
- property.py: use pl.from_epoch(time_unit='s') for correct Unix ms to Date conversion, replacing broken .cast(pl.Date) approach
- dag_utils.py: renamed freshness_parcels to freshness_property to match actual PIPELINE_AUDIT column name
- daily_ingestion_dag.py: updated freshness_property kwarg to match
- PIPELINE_AUDIT.RUN_ID: widened from VARCHAR(36) to VARCHAR(100) to fit Airflow run_id format